### PR TITLE
fdt: increase supported image number to MAX_NUM_IMGS, catch overflows

### DIFF
--- a/inc/fdt.h
+++ b/inc/fdt.h
@@ -207,7 +207,7 @@ typedef uint16_t fdt16_t;
 typedef uint32_t fdt32_t;
 typedef uint64_t fdt64_t;
 
-#define NUM_IMGS 0x5
+#define NUM_IMGS 0x8
 
 #define FDT_TAGSIZE    sizeof(fdt32_t)
 
@@ -320,7 +320,7 @@ const void *fdt_getprop_namelen(const void *fdt, int nodeoffset,
                 const char *name, int namelen, int *lenp);
 const char *fdt_get_alias_namelen(const void *fdt,
                   const char *name, int namelen);
-int parse_fdt(fdt_header_t *fit, image_block_t *images);
+int parse_fdt(fdt_header_t *fit, image_block_t *images, unsigned image_slots);
 int32_t fdt_ro_probe_(const void *fdt);
 int fdt_path_offset_namelen(const void *fdt, const char *path, int namelen);
 int fdt_path_offset(const void *fdt, const char *path);

--- a/src/cst_signer.c
+++ b/src/cst_signer.c
@@ -1292,7 +1292,8 @@ static int process_fdt_images(unsigned long off, uint8_t *infile_buf,
          * g_images + 1 contains all the Images from FIT:
          * Image 0 (uboot@1),Image 1 (fdt@1) ,Image 2 (atf@1)
          */
-        err = parse_fdt(fit_img, &g_images[1]);
+        err = parse_fdt(fit_img, &g_images[1],
+                sizeof(g_images) / sizeof(g_images[0]) - 1);
         if (err) {
             errno = EFAULT;
             fprintf(stderr, "Could not parse FIT image %s\n", strerror(EFAULT));


### PR DESCRIPTION
The previous g_images buffer would be overflown if e.g. TEE was included in the FIT image, causing other globals to be overwritten, and eventually segfaulting the program.
1. Increase the g_images buffer size
2. Pass the buffer size to the parser, and limit the parsing to that limit